### PR TITLE
Update to `pxros-hr` changes and fix doc injection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 syn = { version = "2.0.52", features = ["full"] }
 regex = "1.10.3"
-dotenv = "0.15.0"
 pxros-hr = { version = "0.1.0",  registry = "htc-cargo-index" }
 
 [target.tc162-htc-none]

--- a/documentation_generator/api_docs_generator.rs
+++ b/documentation_generator/api_docs_generator.rs
@@ -1,9 +1,8 @@
-//! 
+//!
 //! SPDX-FileCopyrightText: Veecle GmbH, HighTec EDV-Systeme GmbH
-//! 
+//!
 //! SPDX-License-Identifier: Apache-2.0
-//! 
-use std::collections::HashMap;
+//!
 use std::fmt;
 
 use regex::Regex;
@@ -30,12 +29,6 @@ pub struct ApiDescription {
     see_also: Option<Vec<SeeAlso>>,
     usage: Option<Vec<String>>,
     cop: Option<Cop>,
-}
-
-#[derive(Debug, Deserialize)]
-enum ErrorCodes {
-    Simple(Vec<String>),
-    PlatformSpecific(Vec<HashMap<String, Vec<String>>>),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -158,11 +151,12 @@ fn convert_c_func_to_rust(c_func: &str) -> String {
                 2 => {
                     let (param_type, param_name) = (p[0].trim(), p[1].trim());
                     rust_params.push(format!("{}: {}", param_name, param_type));
-                },
+                }
                 3 => {
-                    let (param_type, param_name, param_type2) = (p[0].trim(), p[1].trim(), p[2].trim());
+                    let (param_type, param_name, param_type2) =
+                        (p[0].trim(), p[1].trim(), p[2].trim());
                     rust_params.push(format!("{}: {} {}", param_name, param_type, param_type2));
-                },
+                }
                 _ => (),
             }
         }
@@ -176,11 +170,19 @@ fn convert_c_func_to_rust(c_func: &str) -> String {
 
     let rust_params_str = rust_params.join(", ");
 
-    format!("fn {}({}) {};", func_name, rust_params_str, rust_return_type)
+    format!(
+        "fn {}({}) {};",
+        func_name, rust_params_str, rust_return_type
+    )
 }
 
 /// Writes a documentation section with a given title and items list, formatted according to `format_type`.
-fn write_section<T, I>(f: &mut fmt::Formatter, title: &str, items: I, format_type: FormatType) -> fmt::Result
+fn write_section<T, I>(
+    f: &mut fmt::Formatter,
+    title: &str,
+    items: I,
+    format_type: FormatType,
+) -> fmt::Result
 where
     T: AsRef<str>,
     I: IntoIterator<Item = T>,
@@ -194,7 +196,7 @@ where
                 writeln!(f, "/// {}", convert_c_func_to_rust(item.as_ref()))?;
                 // writeln!(f, "/// {}", item.as_ref())?;
             }
-        },
+        }
         FormatType::List { literal } => {
             for item in items {
                 if literal {
@@ -203,14 +205,14 @@ where
                     writeln!(f, "/// * {}", item.as_ref())?;
                 }
             }
-        },
+        }
         FormatType::Code => {
             writeln!(f, "/// ```c")?;
             for item in items {
                 writeln!(f, "/// {}", item.as_ref().replace('\t', " "))?;
             }
             writeln!(f, "/// ```")?;
-        },
+        }
     }
 
     Ok(())
@@ -249,7 +251,12 @@ impl fmt::Display for ApiDescription {
 
         // Applies to version
         if !self.applies_to.is_empty() {
-            write_section(f, "Applies To", self.applies_to.iter(), FormatType::List { literal: false })?;
+            write_section(
+                f,
+                "Applies To",
+                self.applies_to.iter(),
+                FormatType::List { literal: false },
+            )?;
         }
 
         // Synopsis
@@ -273,14 +280,24 @@ impl fmt::Display for ApiDescription {
         // Return values
         if let Some(ret_values) = &self.ret_values {
             if !ret_values.is_empty() {
-                write_section(f, "Return Values", ret_values.iter(), FormatType::List { literal: false })?;
+                write_section(
+                    f,
+                    "Return Values",
+                    ret_values.iter(),
+                    FormatType::List { literal: false },
+                )?;
             }
         }
 
         // Error codes
         if let Some(err_codes) = &self.err_codes {
             if !err_codes.is_empty() {
-                write_section(f, "Error Codes", err_codes.iter(), FormatType::List { literal: true })?;
+                write_section(
+                    f,
+                    "Error Codes",
+                    err_codes.iter(),
+                    FormatType::List { literal: true },
+                )?;
             }
         }
 

--- a/documentation_generator/mod.rs
+++ b/documentation_generator/mod.rs
@@ -1,7 +1,7 @@
-//! 
+//!
 //! SPDX-FileCopyrightText: Veecle GmbH, HighTec EDV-Systeme GmbH
-//! 
+//!
 //! SPDX-License-Identifier: Apache-2.0
-//! 
+//!
 pub mod api_docs_generator;
 pub mod transform_input;

--- a/documentation_generator/transform_input.rs
+++ b/documentation_generator/transform_input.rs
@@ -1,8 +1,8 @@
-//! 
+//!
 //! SPDX-FileCopyrightText: Veecle GmbH, HighTec EDV-Systeme GmbH
-//! 
+//!
 //! SPDX-License-Identifier: Apache-2.0
-//! 
+//!
 use std::fs::File;
 use std::io::Read;
 
@@ -45,7 +45,8 @@ pub fn transform_input(file_path: &str) -> String {
 
     // Read the file contents into a string
     let mut contents = String::new();
-    file.read_to_string(&mut contents).expect("Failed to read file");
+    file.read_to_string(&mut contents)
+        .expect("Failed to read file");
 
     // Parse the JSON string into a serde_json::Value
     let mut json_value: Value = serde_json::from_str(&contents).expect("Failed to parse JSON");
@@ -79,10 +80,12 @@ pub fn transform_input(file_path: &str) -> String {
         if let Some(array) = json_value.get_mut(key).and_then(Value::as_array_mut) {
             let target_value = array.first().and_then(|entry| entry.get(target_key));
             *array = match target_value {
-                Some(target_array) if target_array.is_array() => target_array.as_array().unwrap().to_vec(),
+                Some(target_array) if target_array.is_array() => {
+                    target_array.as_array().unwrap().to_vec()
+                }
                 Some(target_string) if target_string.is_string() => {
                     vec![json!(target_string.as_str().unwrap())]
-                },
+                }
                 _ if array.iter().any(|entry| entry.get("ARM-CMX").is_some()) => Vec::new(),
                 _ => array.clone(),
             };
@@ -111,7 +114,9 @@ pub fn transform_input(file_path: &str) -> String {
                     if let Some(item_type) = item.get("type").and_then(|t| t.as_str()) {
                         match item_type {
                             "PP" => {
-                                if let Some(pp_content) = item.get(target_key).and_then(|v| v.as_array()) {
+                                if let Some(pp_content) =
+                                    item.get(target_key).and_then(|v| v.as_array())
+                                {
                                     for content in pp_content {
                                         if let Some(content_text) = content.as_str() {
                                             transformed_text.push('\n');
@@ -119,21 +124,26 @@ pub fn transform_input(file_path: &str) -> String {
                                             transformed_text.push('\n');
                                         }
                                     }
-                                } else if let Some(text) = item.get("text").and_then(|t| t.as_str()) {
+                                } else if let Some(text) = item.get("text").and_then(|t| t.as_str())
+                                {
                                     transformed_text.push('\n');
                                     transformed_text.push_str(text);
                                     transformed_text.push('\n');
                                 }
-                            },
+                            }
                             "BL" => {
-                                if let Some(bullets) = item.get(target_key).and_then(|v| v.as_array()) {
+                                if let Some(bullets) =
+                                    item.get(target_key).and_then(|v| v.as_array())
+                                {
                                     for bullet in bullets {
                                         if let Some(bullet_text) = bullet.as_str() {
                                             transformed_text.push_str("\n * ");
                                             transformed_text.push_str(bullet_text);
                                         }
                                     }
-                                } else if let Some(bullets) = item.get("text").and_then(|t| t.as_array()) {
+                                } else if let Some(bullets) =
+                                    item.get("text").and_then(|t| t.as_array())
+                                {
                                     for bullet in bullets {
                                         if let Some(bullet_text) = bullet.as_str() {
                                             transformed_text.push_str("\n * ");
@@ -142,8 +152,8 @@ pub fn transform_input(file_path: &str) -> String {
                                     }
                                     transformed_text.push('\n');
                                 }
-                            },
-                            _ => {},
+                            }
+                            _ => {}
                         }
                     }
                 }
@@ -172,7 +182,9 @@ pub fn transform_input(file_path: &str) -> String {
             for key in ["BeforeCall", "AfterCall", "BestPractice"].iter() {
                 if let Some(section) = cop.get_mut(*key).and_then(|s| s.as_array_mut()) {
                     if let Some(first) = section.first_mut() {
-                        if let Some(target_array) = first.get_mut(target_key).and_then(|ta| ta.as_array_mut()) {
+                        if let Some(target_array) =
+                            first.get_mut(target_key).and_then(|ta| ta.as_array_mut())
+                        {
                             let mut new_section = Vec::new();
                             for item in target_array.iter() {
                                 if let Some(text) = item.as_str() {
@@ -196,5 +208,6 @@ pub fn transform_input(file_path: &str) -> String {
     transform_description(&mut json_value, "TC23");
     transform_cop(&mut json_value, "TC23");
 
-    serde_json::to_string_pretty(&json_value).expect("[*] =====> Failed to transform input file !!!")
+    serde_json::to_string_pretty(&json_value)
+        .expect("[*] =====> Failed to transform input file !!!")
 }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,9 +1,9 @@
 //! Generated raw bindings.
-//! 
+//!
 //! SPDX-FileCopyrightText: Veecle GmbH, HighTec EDV-Systeme GmbH
-//! 
+//!
 //! SPDX-License-Identifier: Apache-2.0
-//! 
+//!
 use core::marker::PhantomData;
 
 use crate::PxResult;
@@ -131,7 +131,9 @@ mod ffi {
 
     // TODO: Hardcode the type sizes for the following types to match for the
     // HighTec compiler.
-    pub use core::ffi::{c_char, c_int, c_longlong, c_schar, c_short, c_uchar, c_ulonglong, c_ushort, c_void};
+    pub use core::ffi::{
+        c_char, c_int, c_longlong, c_schar, c_short, c_uchar, c_ulonglong, c_ushort, c_void,
+    };
 
     pub use {i32 as c_long, u32 as c_uint, u32 as c_ulong};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,11 @@
 //!
 //! This crate "wraps" the raw bindings in Rust data structures and provides a more
 //! rusty interface. It minimizes logical changes.
-//! 
+//!
 //! SPDX-FileCopyrightText: Veecle GmbH, HighTec EDV-Systeme GmbH
-//! 
+//!
 //! SPDX-License-Identifier: Apache-2.0
-//! 
+//!
 #![cfg_attr(not(test), no_std)]
 
 use bindings::PxError_t;

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -7,11 +7,11 @@
 //!
 //! For now, we only expose the types but only defer to the default impl
 //! when using them.
-//! 
+//!
 //! SPDX-FileCopyrightText: Veecle GmbH, HighTec EDV-Systeme GmbH
-//! 
+//!
 //! SPDX-License-Identifier: Apache-2.0
-//! 
+//!
 use core::ops::Range;
 
 use super::bindings::*;


### PR DESCRIPTION
This is based on https://github.com/hightec-rt/pxros-hr/pull/1.
With this PR, the docs are injected into the bindings again and the bindings generation can be configured.
I also fixed clippy complaints and ran the formatter.